### PR TITLE
Added tree view functionality to details.html page

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -79,7 +79,7 @@ input:focus, textarea:focus, select:focus {
 }
 
 /* Center Content Horizontally, Align to Top Vertically */
-.container {
+.page-container {
     display: flex;
     justify-content: center; /* Horizontal centering */
     align-items: flex-start; /* Align to top vertically */
@@ -90,7 +90,7 @@ input:focus, textarea:focus, select:focus {
 
 /* Main Content Box */
 .content-box {
-    max-width: 1000px;
+    /* max-width: 1000px; /* enables max content width */
     width: 100%;
     padding: 20px;
     border: 2px solid #ffaa33;

--- a/static/css/tree.css
+++ b/static/css/tree.css
@@ -1,0 +1,99 @@
+/* Overall Page Container */
+.page-container {
+    display: flex;
+    gap: 20px; /* Add a gap between the two panes */
+    width: 100%;
+    /* max-width: 1200px; /* Optional: limit the width for readability */
+    margin: 0 auto; /* Center the content on the page */
+    align-items: stretch; /* Match the height of both panes */
+    /* height: calc(100vh - 40px); /* Adjust to available viewport height */
+}
+
+/* Main Content Pane */
+.main-pane {
+    width: 70%; /* Take the remaining 70% */
+    background-color: #1a1a1a;
+    color: #ddd;
+    overflow-y: scroll;
+    height: 100%; /* Match the parent container's height */
+    box-sizing: border-box; /* Ensure padding is included in width */
+}
+
+/* Tree Pane */
+.tree-pane {
+    width: 30%; /* Take 30% of the available width */
+    background-color: #1a1a1a;
+    color: #ddd;
+    font-family: monospace;
+    overflow-y: auto; /* Allow vertical scrolling if needed */
+    position: sticky; /* Sticky positioning for floating behavior */
+    top: 30px; /* Add padding from the top of the viewport */
+    height: calc(100vh - 80px); /* Limit height with padding on top and bottom */
+    padding-top: 0px; /* No padding on top so header sits in the right place */
+}
+
+/* Tree Header */
+.tree-header {
+    position: sticky;
+    top: 0;
+    background-color: #1a1a1a; /* Match the background color of the pane */
+    z-index: 1; /* Ensure the header stays above scrollable content */
+    padding: 5px; /* Add spacing below the header */
+}
+
+/* Sticky Folder Header */
+.sticky-folder {
+    position: sticky;
+    top: 30px; /* Below the main "Folder Structure" header */
+    background-color: #1a1a1a;
+    z-index: 2; /* Ensure it stays above the tree content */
+    padding: 5px 10px;
+    font-weight: bold;
+    font-style: italic;
+    color: #ffaa33; /* Amber to highlight current folder */
+    border-bottom: 1px solid #555; /* Visual separation */
+}
+
+/* Tree Content */
+.tree-content {
+    overflow-y: auto; /* Allow vertical scrolling for the tree data */
+    flex: 1; /* Let the content take the remaining height */
+    margin-top: 10px; /* space below the sticky header */
+}
+
+/* Preserve whitespace in true 'pre' fashion */
+#ascii-tree {
+    margin: 0;
+    white-space: pre;
+}
+
+/* Folders (Non-Clickable) */
+.folder {
+    color: #ddd; /* Brighter text color for readability */
+    font-style: italic; /* Add italics to differentiate */
+    cursor: default; /* No pointer cursor for folders */
+}
+
+/* ELF Files (Clickable) */
+.elf-file {
+    color: #00ffaa; /* Teal green indicates clickable */
+    cursor: pointer;
+}
+
+/* Non-ELF Files (Non-Clickable) */
+.non-elf-file {
+    color: #555; /* Dark gray for non-ELF files */
+    cursor: not-allowed;
+}
+
+/* Highlighted Node (Recently Clicked) */
+.highlighted-node {
+    color: #ffaa33; /* Amber indicates the file was just clicked */
+    font-weight: bold;
+}
+
+/* Highlighted Row in Binary Results */
+.binary-table tr.highlighted {
+    background-color: #00ffaa; /* Teal green background for visibility */
+    color: #000; /* Contrast text color */
+}

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -83,6 +83,13 @@ document.addEventListener("DOMContentLoaded", function () {
         detailsRow.style.display = detailsRow.style.display === "table-row" ? "none" : "table-row";
     }
 
+    function toggleAllDetails(expand) {
+        const detailRows = document.querySelectorAll(".binary-details-row");
+    
+        detailRows.forEach((row) => {
+            row.style.display = expand ? "table-row" : "none";
+        });
+    }
 
     // Apply filters and render
     async function applyFilters() {
@@ -139,6 +146,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
         // Render the final filtered list
         renderBinaries(filteredBinaries);
+
+        // Update the tree view
+        window.updateTreeView(filteredBinaries);
     }
 
     toggleFiltersButton.addEventListener("click", () => {
@@ -173,8 +183,16 @@ document.addEventListener("DOMContentLoaded", function () {
         
         // Render the full list of binaries
         renderBinaries(binaries);
+
+        let originalBinaries = [...binaries];
+        // Reset `matching_strings` for all binaries
+        originalBinaries.forEach((binary) => {
+            binary.matching_strings = null;
+        });
+
+        // Reset the tree view to the original structure
+        window.updateTreeView(originalBinaries);
     });
 
     renderBinaries(binaries); // Render all binaries initially
 });
-

--- a/static/js/tree.js
+++ b/static/js/tree.js
@@ -1,0 +1,171 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const asciiTreeElement = document.getElementById("ascii-tree");
+    const binaryResults = document.getElementById("binary-results");
+    let originalTreeData = []; // To store the unfiltered tree structure
+
+    // Fetch tree data and render it
+    fetch(`/projects/${projectId}/tree`)
+        .then((response) => response.json())
+        .then((treeData) => {
+            if (!treeData || !treeData.children) {
+                console.error("Tree data is empty or malformed:", treeData);
+                document.getElementById("ascii-tree").innerHTML = "<p>Error loading folder structure.</p>";
+                return;
+            }
+            originalTreeData = treeData; // Save the complete unfiltered tree structure
+            const ascii = generateAsciiTree(treeData);
+            asciiTreeElement.innerHTML = ascii; // Use HTML for interactivity
+            
+            setupFolderTracking(); // Track folder visibility
+            addTreeNodeClickHandlers(); // Attach click handlers after rendering
+        }).catch((error) => {
+            console.error("Failed to fetch tree data:", error);
+            document.getElementById("ascii-tree").innerHTML = "<p>Error loading folder structure.</p>";
+        });
+
+        function generateAsciiTree(node, prefix = "", isLast = true) {
+            const isFile = !node.children || node.children.length === 0;
+            const isElfFile = binaries.some((binary) => binary.path === node.path);
+            const isFolder = !isFile;
+        
+            const dataPath = isElfFile ? `data-path="${node.path}"` : "";
+            const folderData = isFolder ? `data-folder="${node.path}"` : "";
+            const clickableClass = isElfFile ? "clickable-node" : isFolder ? "folder-node" : "non-clickable-node";
+            const colorClass = isElfFile
+                ? "elf-file"
+                : isFolder
+                ? "folder"
+                : "non-elf-file";
+        
+            let result = `<span class="${clickableClass} ${colorClass}" ${dataPath} ${folderData}>`;
+            result += prefix + (isLast ? "└── " : "├── ");
+            result += node.name + (isFolder ? "/" : "");
+            result += "</span>\n";
+        
+            if (node.children && node.children.length > 0) {
+                const newPrefix = prefix + (isLast ? "    " : "│   ");
+                node.children.forEach((child, index) => {
+                    const lastChild = index === node.children.length - 1;
+                    result += generateAsciiTree(child, newPrefix, lastChild);
+                });
+            }
+            return result;
+        }
+
+    function setupFolderTracking() {
+        const treePane = document.querySelector(".tree-pane"); // Main scrollable container
+        const folderNodes = document.querySelectorAll('[data-folder]');
+        const stickyFolder = document.getElementById("current-folder");
+    
+        function updateStickyFolder() {
+            let closestFolder = null;
+            let closestDistance = Infinity;
+    
+            folderNodes.forEach((node) => {
+                const rect = node.getBoundingClientRect();
+                const treePaneRect = treePane.getBoundingClientRect();
+    
+                // Calculate the distance from the node's top to the tree-pane's top
+                const distance = rect.top - treePaneRect.top;
+    
+                if (distance >= 0 && distance < closestDistance) {
+                    closestDistance = distance;
+                    closestFolder = node;
+                }
+            });
+    
+            if (closestFolder) {
+                const folderName = closestFolder.getAttribute("data-folder");
+                stickyFolder.textContent = folderName || "/";
+            }
+        }
+    
+        // Attach scroll listener to the correct container
+        treePane.addEventListener("scroll", updateStickyFolder);
+    
+        // Initial call to set the folder correctly
+        updateStickyFolder();
+    }
+
+    function rebuildTree(node, matchingBinaries) {
+        console.log("Rebuilding node:", node);
+        console.log("Matching binaries:", matchingBinaries);
+    
+        if (!node) {
+            return null;
+        }
+    
+        // If matchingBinaries contains all binaries, return the node as-is
+        const includeAll = matchingBinaries.length === binaries.length;
+    
+        if (!node.children) {
+            // Leaf node: check if it's a matching binary or include all
+            const isMatchingBinary = includeAll || matchingBinaries.some((binary) => binary.path === node.path);
+            return isMatchingBinary ? { ...node, children: [] } : null;
+        }
+    
+        // Internal node: filter its children recursively
+        const filteredChildren = node.children
+            .map((child) => rebuildTree(child, matchingBinaries))
+            .filter(Boolean);
+    
+        if (includeAll || filteredChildren.length > 0 || matchingBinaries.some((binary) => binary.path === node.path)) {
+            // If this node has matching children, is itself a matching binary, or includeAll is true
+            return { ...node, children: filteredChildren };
+        }
+    
+        // Otherwise, discard this node
+        return null;
+    }
+
+    // Update the tree view when filters are applied
+    function updateTreeView(filteredBinaries) {
+        console.log("Updating tree view with binaries:", filteredBinaries);
+        const filteredTree = rebuildTree(originalTreeData, filteredBinaries);
+    
+        if (!filteredTree) {
+            console.error("Filtered tree is empty or invalid.");
+            document.getElementById("ascii-tree").innerHTML = "<p>No matching binaries in the tree.</p>";
+            return;
+        }
+    
+        const prunedAsciiTree = generateAsciiTree(filteredTree);
+        const asciiTreeElement = document.getElementById("ascii-tree");
+        asciiTreeElement.innerHTML = prunedAsciiTree;
+    
+        addTreeNodeClickHandlers();
+    }
+
+    function addTreeNodeClickHandlers() {
+        const nodes = document.querySelectorAll(".clickable-node");
+        nodes.forEach((node) => {
+            node.addEventListener("click", (event) => {
+                event.stopPropagation();
+                const path = node.getAttribute("data-path");
+                scrollToBinary(path);
+                highlightNode(node);
+            });
+        });
+    }
+
+    function scrollToBinary(path) {
+        const rows = binaryResults.querySelectorAll("tr");
+        rows.forEach((row) => {
+            if (row.textContent.includes(path)) {
+                row.scrollIntoView({ behavior: "smooth", block: "center" }); // Align the binary in the center of the viewport
+                row.classList.add("highlighted");
+
+                setTimeout(() => row.classList.remove("highlighted"), 3000); // Remove highlight after 3 seconds
+            }
+        });
+    }
+
+    function highlightNode(node) {
+        const allNodes = document.querySelectorAll(".clickable-node");
+        allNodes.forEach((n) => n.classList.remove("highlighted-node"));
+        node.classList.add("highlighted-node");
+    }
+
+    // Expose updateTreeView to be callable from other files (like filter.js)
+    window.updateTreeView = updateTreeView;
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,8 +20,9 @@
         </nav>
     </header>
     <main>
-        <div class="container">
-            <div class="content-box">
+        <div class="page-container">
+            {% block sidecontent %}{% endblock %}
+            <div class="content-box main-pane">
                 {% block content %}{% endblock %}
             </div>
         </div>

--- a/templates/details.html
+++ b/templates/details.html
@@ -2,6 +2,25 @@
 
 {% block title %}{{ project.name }}{% endblock %}
 
+{% block head %}
+  {{ super() }}
+  <link rel="stylesheet" href="/static/css/tree.css">
+{% endblock %}
+
+{% block sidecontent %}
+<div class="content-box tree-pane">
+    <div class="tree-header">
+        <h3>Folder Structure</h3>
+        <div class="sticky-folder">
+            <span id="current-folder">/</span>
+        </div>
+    </div>
+    <div class="tree-content">
+        <pre id="ascii-tree"></pre>
+    </div>
+</div>
+{% endblock %}
+
 {% block content %}
 <!-- Breadcrumb Navigation -->
 <nav class="breadcrumb">
@@ -82,4 +101,5 @@
     const projectId = {{ project.id }};
 </script>
 <script src="/static/js/filter.js"></script>
+<script src="/static/js/tree.js"></script>
 {% endblock %}


### PR DESCRIPTION
Woohoo, new tree view! When navigating to details.html, a full 'tree' view of the scanned filesystem will be generated and viewable on the left side of the application.
- This tree view will highlight all scanned binaries in bright green
- If these binaries are clicked, it will scroll the user directly to that binary's details in the normal binary details table
- Any non-binaries that were present in the filesystem are still shown, just in dark gray to indicate not being clickable
- A floating bar at the top of the tree keeps track of the currently-displayed folder even when scrolling, helping to navigate extremely large firmware filesystems.

### In total, this PR encompasses:

Bugfixes:
- Updates filters.js to fix previously-broken "Expand All" and "Collapse All" buttons

New features!
- ✅ Updates the base.html template to include a new "sidecontent" element that can be rendered alongside the existing main "content" block.
- ✅ Adds new route to project_routes.py to fetch a JSON representation of the full filesystem structure of the scanned folder
- ✅ **Adds a new pane to details.html that renders the full filesystem tree of the scanned folder**

Changes that aren't new features and also aren't bugfixes:
- Removes the artificial page width limitation of 1000px
    - This is something that I could see being re-introduced in the future once the table of binary details is made prettier
    - ...but for now it kinda seems like this app will be 1080p widescreen only
    - 😭 If only I were better at responsive design 😭 